### PR TITLE
Add email verification mechanism using nodemailer

### DIFF
--- a/BackEnd/.env.example
+++ b/BackEnd/.env.example
@@ -3,3 +3,10 @@ DB_PASSWORD=
 DB_HOST=localhost
 DB_USER=root # mysql username
 DB_DATABASE=anime_hub # database name
+
+# nodemailer email credentials
+EMAIL=example@gmail.com # email address
+EMAIL_PASSWORD= # account password or applcation password
+
+BACKEND=http://localhost:5000 # backend server
+FRONTEND=http://localhost:5173 # frontend server

--- a/BackEnd/package.json
+++ b/BackEnd/package.json
@@ -10,6 +10,7 @@
     "morgan": "^1.10.0",
     "mysql": "^2.18.1",
     "mysql2": "^3.2.1",
+    "nodemailer": "^6.9.6",
     "nodemon": "^3.0.1",
     "puppeteer-core": "^19.10.1"
   }

--- a/BackEnd/server.js
+++ b/BackEnd/server.js
@@ -2,6 +2,8 @@ const express = require("express");
 const mysql = require("mysql2/promise");
 const cors = require("cors");
 require("dotenv").config();
+const crypto = require("crypto");
+const nodemailer = require("nodemailer");
 // const morgan = require("morgan");
 const { check, validationResult } = require("express-validator");
 const port = 5000;
@@ -22,6 +24,77 @@ async function idExists(db, tableName, ID_key, ID) {
         throw err;
     }
 }
+
+const sendMail = (name, email, token) => {
+    const transporter = nodemailer.createTransport({
+        service: "gmail",
+        auth: {
+            user: process.env.EMAIL,
+            pass: process.env.EMAIL_PASSWORD,
+        },
+    });
+
+    const mailOptions = {
+        from: process.env.EMAIL,
+        to: email,
+        subject: "AnimeHub Account Verification",
+        html: `
+          <html>
+            <head>
+              <style>
+                /* Add CSS styles for better email formatting */
+                body {
+                  font-family: Arial, sans-serif;
+                  background-color: #f4f4f4;
+                  text-align: center;
+                }
+                .container {
+                  max-width: 600px;
+                  margin: 0 auto;
+                  padding: 20px;
+                  background-color: #fff;
+                  border-radius: 10px;
+                  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+                }
+                h1 {
+                  color: #333;
+                }
+                p {
+                  font-size: 16px;
+                }
+                a {
+                  display: inline-block;
+                  padding: 10px 20px;
+                  margin: 20px 0;
+                  background-color: #007BFF;
+                  color: #fff !important;
+                  text-decoration: none;
+                  border-radius: 5px;
+                }
+              </style>
+            </head>
+            <body>
+              <div class="container">
+                <h1>Hello ${name},</h1>
+                <p>Thank you for signing up with AnimeHub! To get started, please verify your email by clicking the button below:</p>
+                <a href="http://localhost:5000/verify/${token}">Verify Your Email</a>
+                <p>If the button above doesn't work, you can also copy and paste the following link into your web browser:</p>
+                <p><a href="http://localhost:5000/verify/${token}">http://localhost:5000/verify/${token}</a></p>
+                <p>If you didn't sign up for an AnimeHub account, please disregard this email.</p>
+              </div>
+            </body>
+          </html>
+        `,
+    };
+
+    transporter.sendMail(mailOptions, (error, info) => {
+        if (error) {
+            console.error("Error sending email: " + error);
+        } else {
+            console.log("Email sent: " + info.response);
+        }
+    });
+};
 
 app.use(cors());
 // app.use(morgan());
@@ -57,17 +130,19 @@ app.use((req, res, next) => {
 app.post("/signup", async (req, res, next) => {
     try {
         console.log(req.body);
-        const sql = "INSERT INTO user(name,email,password_hash,created_at,is_admin) VALUES (?,?,?,curdate(),0)";
-        const values = [req.body.name, req.body.email, req.body.password];
+        const emailToken = crypto.randomBytes(64).toString("hex");
+        const sql = "INSERT INTO user(name,email,password_hash,created_at,is_admin,is_verified,emailToken) VALUES (?,?,?,curdate(),0,0,?)";
+        const values = [req.body.name, req.body.email, req.body.password, emailToken];
         const [result] = await db.query(sql, values, (err, data) => {
             if (err) {
                 return res.json(err);
             }
             return res.json(data);
         });
+        sendMail(req.body.name, req.body.email, emailToken);
         return res.json({ success: true, msg: `${req.body.name} added` });
     } catch (err) {
-        if ((err.code = "ER_DUP_ENTRY")) {
+        if (err.code === "ER_DUP_ENTRY") {
             return res.json({ success: false, msg: "User already exists" });
         } else {
             next(err);
@@ -75,20 +150,47 @@ app.post("/signup", async (req, res, next) => {
     }
 });
 
+//verify user api
+app.get("/verify/:token", async (req, res) => {
+    console.log(req.params);
+    const { token } = req.params;
+    try {
+        const sql = "SELECT user_id,`name`,email,created_at,is_verified,emailToken FROM user WHERE emailToken = ?";
+        let data = (await db.query(sql, [token]))[0];
+        if (data.length) {
+            console.log(data);
+            const userId = data[0].user_id;
+            const updateSql = "UPDATE user SET is_verified = 1 WHERE user_id = ?";
+            await db.query(updateSql, [userId]);
+
+            // Redirect to the login page (adjust the URL as needed)
+            return res.redirect("http://localhost:5173/login");
+        } else throw "Invalid token";
+    } catch (error) {
+        next(error);
+    }
+});
+
 // login api
 app.post(
     "/login",
-    [
-        check("email", "Email length error").isEmail().isLength({ min: 10, max: 30 }),
-        check("password", "password length 8-10").isLength({ min: 8 }),
-    ],
+    [check("email", "Email length error").isEmail().isLength({ min: 10, max: 30 }), check("password", "password length 8-10").isLength({ min: 8 })],
     async (req, res, next) => {
         console.log(req.body);
         try {
-            const sql = "SELECT user_id,`name`,email,created_at FROM user WHERE email = ? AND password_hash = ?";
-            let data = (await db.query(sql, [req.body.email, req.body.password]))[0];
-            if (data.length) return res.json({ success: true, data: data[0] });
-            else throw "Invalid Credentials";
+            const sql = "SELECT user_id,`name`,email,created_at,is_verified  FROM user WHERE email = ? AND password_hash = ?";
+            const [data] = await db.query(sql, [req.body.email, req.body.password]);
+
+            if (data.length) {
+                const user = data[0];
+                if (user.is_verified) {
+                    return res.json({ success: true, data: user });
+                } else {
+                    return res.json({ success: false, msg: "Please verify your email before logging in." });
+                }
+            } else {
+                throw "Invalid Credentials";
+            }
         } catch (err) {
             next(err);
         }
@@ -221,9 +323,7 @@ app.get("/anime/:anime_id", async (req, res, next) => {
     anime_id = parseInt(anime_id);
     try {
         let anime = (await db.query("SELECT * FROM anime WHERE anime_id=?", [anime_id]))[0][0];
-        let genres = (await db.query("SELECT label FROM anime_genre WHERE anime_id = ?", [anime_id]))[0].map(
-            (tuple) => tuple.label
-        );
+        let genres = (await db.query("SELECT label FROM anime_genre WHERE anime_id = ?", [anime_id]))[0].map((tuple) => tuple.label);
         let characters = (
             await db.query(
                 "SELECT * FROM anime_character_junction INNER JOIN `character` ON anime_character_junction.character_id=`character`.character_id WHERE anime_character_junction.anime_id=?",
@@ -329,11 +429,7 @@ app.post("/user/:user_id/list/update", async (req, res, next) => {
         if (!(await db.query("SELECT * FROM list_item WHERE anime_id=? AND user_id=?", [anime_id, user_id]))[0].length)
             throwError("Anime is not added to watchlist");
 
-        await db.query("UPDATE list_item SET `type`= ? WHERE user_id = ? AND anime_id = ? ", [
-            item_status,
-            user_id,
-            anime_id,
-        ]);
+        await db.query("UPDATE list_item SET `type`= ? WHERE user_id = ? AND anime_id = ? ", [item_status, user_id, anime_id]);
 
         return res.json({ success: true });
     } catch (err) {

--- a/BackEnd/server.js
+++ b/BackEnd/server.js
@@ -77,9 +77,9 @@ const sendMail = (name, email, token) => {
               <div class="container">
                 <h1>Hello ${name},</h1>
                 <p>Thank you for signing up with AnimeHub! To get started, please verify your email by clicking the button below:</p>
-                <a href="http://localhost:5000/verify/${token}">Verify Your Email</a>
+                <a href="${process.env.BACKEND}/verify/${token}">Verify Your Email</a>
                 <p>If the button above doesn't work, you can also copy and paste the following link into your web browser:</p>
-                <p><a href="http://localhost:5000/verify/${token}">http://localhost:5000/verify/${token}</a></p>
+                <p><a href="${process.env.BACKEND}/verify/${token}">${process.env.BACKEND}/verify/${token}</a></p>
                 <p>If you didn't sign up for an AnimeHub account, please disregard this email.</p>
               </div>
             </body>
@@ -164,7 +164,7 @@ app.get("/verify/:token", async (req, res) => {
             await db.query(updateSql, [userId]);
 
             // Redirect to the login page (adjust the URL as needed)
-            return res.redirect("http://localhost:5173/login");
+            return res.redirect(`${process.env.FRONTEND}/login`);
         } else throw "Invalid token";
     } catch (error) {
         next(error);


### PR DESCRIPTION
Closes #8 

Used nodeMailer to send verification emails, mandated users to verify accounts before logging in [screenshot below]

![image](https://github.com/Peacexoom/AnimeHub/assets/109443065/6189d279-4f7f-48de-a187-5238ad5d617e)

Sample email:
![image](https://github.com/Peacexoom/AnimeHub/assets/109443065/6ee3e0b0-140c-4cb7-b5c9-097a0db492f7)

Note: Please add the email and password to be used for sending the email to the env file and make sure that the account is allowed to login without verification, if 2FA is enabled for Gmail please create an app password and add that in the env file. For more detailed check - https://nodemailer.com/usage/using-gmail/
