### PR TITLE
Updated the Detail.jsx Genre tags

### DIFF
--- a/FrontEnd/src/components/Detail.jsx
+++ b/FrontEnd/src/components/Detail.jsx
@@ -16,7 +16,7 @@ export const Detail = () => {
     const { setLoader } = useContext(Contextpage);
     const { anime_id } = useParams();
     const [showOptions, setShowOptions] = useState(false); // Define showOptions state
-
+    const { setActiveGenre} = useContext(Contextpage);//To set the activegenre on the genre page
     const [animedet, setAnimedet] = useState();
     const [isBookmarked, setIsBookmarked] = useState(!!animedet?.is_added);
     // const [castdata, setCastdata] = useState([]);
@@ -188,7 +188,7 @@ export const Detail = () => {
                                 <div className='flex justify-center flex-wrap'>
                                     {animedet.genres.map((genreLabel, index) => (
                                         <>
-                                            <div key={index} className='text-white font-semibold bg-gray-800 rounded-full px-4 py-1 m-2'>{genreLabel}</div>
+                                            <Link to="/genres" key={index} onClick={() => setActiveGenre(genreLabel)}  className='text-white font-semibold bg-gray-800 rounded-full px-4 py-1 m-2'>{genreLabel}</Link>
                                         </>
                                     ))}
                                 </div>


### PR DESCRIPTION
Updated the genre tags so that they take the user to the genre page showing the animes with the same genre tags.
Example:
<img width="1440" alt="Screenshot 2023-10-17 at 3 09 35 PM" src="https://github.com/Peacexoom/AnimeHub/assets/110195478/9e6e0538-8dd5-488d-a614-7c392cb5e87c">
<img width="1440" alt="Screenshot 2023-10-17 at 3 10 00 PM" src="https://github.com/Peacexoom/AnimeHub/assets/110195478/8830c5b8-c2fd-4559-9451-79e0d6791244">
