### PR TITLE
feat: provide graceful shutdown for database & server forcefully closed

### DIFF
--- a/BackEnd/db.js
+++ b/BackEnd/db.js
@@ -26,3 +26,8 @@ exports.idExists = async (db, tableName, ID_key, ID) => {
     throw err;
   }
 };
+
+exports.closeConnection = async () => {
+  await db.end();
+  console.log("DB Connection Closed");
+}

--- a/BackEnd/server.js
+++ b/BackEnd/server.js
@@ -1,4 +1,5 @@
 require("dotenv").config();
+const { connectToDB, closeConnection } = require('./db');
 
 // constants
 const PORT = 5000;
@@ -10,12 +11,28 @@ global.throwError = (msg) => {
 
 async function main() {
   const app = require("./app.js");
-  app.listen(PORT, () => {
+  const server = app.listen(PORT, () => {
     console.log("Server running on port", PORT);
+  });
+
+  process.on('SIGTERM', () => {
+    console.log('SIGTERM signal received: closing HTTP server');
+    server.close(() => {
+      console.log('SIGTERM close server');
+    });
+    closeConnection();
+  });
+
+  process.on('SIGINT', () => {
+    console.log('SIGINT signal received: closing HTTP server');
+    server.close(() => {
+      console.log('SIGINT close server');
+    });
+    closeConnection();
   });
 }
 
 (async (callback) => {
-  await require("./db.js").connectToDB();
+  await connectToDB();
   await callback();
 })(main);


### PR DESCRIPTION
#51 
To test the safely closed database & server, you can use the setTimout function in the endpoint. Try to set a 5-10 seconds wait time, then terminate the running server forcefully in your terminal.
The result will wait for the timeout and then successfully finish query execution. Then the console will exit the running server.

@moonpatel @Peacexoom 